### PR TITLE
Use api key names for signed search keys rather than ids

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,6 @@ Creating a search key that will only search over the body field.
 .. code-block:: python
 
     >>> api_key = 'api-mu75psc5egt9ppzuycnc2mc3'
-    >>> api_key_id = '42'
-    >>> signed_search_key = Client.create_signed_search_key(api_key, api_key_id, {'search_fields': { 'body': {}}})
+    >>> api_key_name = 'my-api-token'
+    >>> signed_search_key = Client.create_signed_search_key(api_key, api_key_name, {'search_fields': { 'body': {}}})
     >>> client = Client(account_host_key, signed_search_key)

--- a/swiftype_app_search/__version__.py
+++ b/swiftype_app_search/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'swiftype_app_search'
 __description__ = 'An API client for Swiftype App Search'
 __url__ = 'https://github.com/swiftype/swiftype-app-search-python'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'Swiftype'
 __author_email__ = 'eng@swiftype.com'

--- a/swiftype_app_search/client.py
+++ b/swiftype_app_search/client.py
@@ -127,15 +127,15 @@ class Client:
         return self.swiftype_session.request('get', endpoint, json=options)
 
     @staticmethod
-    def create_signed_search_key(api_key, api_key_id, options):
+    def create_signed_search_key(api_key, api_key_name, options):
         """
         Creates a signed API key that will overwrite all search options (except
         filters) made with this key.
 
         :param api_key: An API key to use for this client.
-        :param api_token_id: A unique API Key identifier
+        :param api_key_name: The unique name for the API Key
         :param options: Search options to override.
         :return: A JWT signed api token.
         """
-        options['api_key_id'] = api_key_id
+        options['api_key_name'] = api_key_name
         return jwt.encode(options, api_key, algorithm=Client.SIGNED_SEARCH_TOKEN_JWT_ALGORITHM)


### PR DESCRIPTION
This is a breaking change.

We're going to stop exposing API Key id's in the dashboard, and rely on the `name` attribute instead.