### PR TITLE
Updated reporting headers

### DIFF
--- a/swiftype_app_search/__version__.py
+++ b/swiftype_app_search/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'swiftype_app_search'
 __description__ = 'An API client for Swiftype App Search'
 __url__ = 'https://github.com/swiftype/swiftype-app-search-python'
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 __author__ = 'Swiftype'
 __author_email__ = 'eng@swiftype.com'

--- a/swiftype_app_search/swiftype_request_session.py
+++ b/swiftype_app_search/swiftype_request_session.py
@@ -12,7 +12,8 @@ class SwiftypeRequestSession:
 
         headers = {
             'Authorization': "Bearer {}".format(api_key),
-            'User-Agent': "swiftype-app-search-python/{}".format(swiftype_app_search.__version__),
+            'X-Swiftype-Client': 'swiftype-app-search-python',
+            'X-Swiftype-Client-Version': swiftype_app_search.__version__,
             'content-type': 'application/json; charset=utf8'
         }
         self.session.headers.update(headers)

--- a/tests/test_swiftype_request_session.py
+++ b/tests/test_swiftype_request_session.py
@@ -28,14 +28,15 @@ class TestSwiftypeRequestSession(TestCase):
         headers_to_check = {
             k: v
             for k, v in iteritems(self.swiftype_session.session.headers)
-            if k in ['Authorization', 'User-Agent']
+            if k in ['Authorization', 'X-Swiftype-Client', 'X-Swiftype-Client-Version']
         }
         version = swiftype_app_search.__version__
         self.assertEqual(
             headers_to_check,
             {
                 'Authorization': 'Bearer {}'.format(self.api_host_key),
-                'User-Agent': 'swiftype-app-search-python/{}'.format(version)
+                'X-Swiftype-Client': 'swiftype-app-search-python',
+                'X-Swiftype-Client-Version': version
             }
         )
 


### PR DESCRIPTION
[ENG-1107] Clients should send a header with Client type and version

Fixes #13

This lets us more accurately report on client type and version. It also
keeps the User-Agent header free for whatever the platforms
natural User-Agent value is.