### PR TITLE
Add client functionality for synonym management

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,121 @@ The client can be configured to use a managed deploy by adjusting the `base_endp
 {'deleted': True}
 ```
 
+### List all synonym sets in an engine
+
+#### With default pagination (a page size of 20)
+
+```python
+>>> client.list_synonym_sets('us-national-parks')
+{
+  "meta": {
+    "page": {
+      "current": 1,
+      "total_pages": 1,
+      "total_results": 3,
+      "size": 20
+    }
+  },
+  "results": [
+    {
+      "id": "syn-5b11ac66c9f9292013220ad3",
+      "synonyms": [
+        "park",
+        "trail"
+      ]
+    },
+    {
+      "id": "syn-5b11ac72c9f9296b35220ac9",
+      "synonyms": [
+        "protected",
+        "heritage"
+      ]
+    },
+    {
+      "id": "syn-5b11ac66c9f9292013220ad3",
+      "synonyms": [
+        "hectares",
+        "acres"
+      ]
+    }
+  ]
+}
+```
+
+#### With custom pagination
+
+```python
+>>> client.list_synonym_sets('us-national-parks', size=1, current=1)
+{
+  "meta": {
+    "page": {
+      "current": 1,
+      "total_pages": 3,
+      "total_results": 3,
+      "size": 1
+    }
+  },
+  "results": [
+    {
+      "id": "syn-5b11ac66c9f9292013220ad3",
+      "synonyms": [
+        "park",
+        "trail"
+      ]
+    }
+  ]
+}
+```
+
+### Get a single synonym sets
+
+```python
+>>> client.get_synonym_set('us-national-parks', 'syn-5b11ac66c9f9292013220ad3')
+{
+  "id": "syn-5b11ac66c9f9292013220ad3",
+  "synonyms": [
+    "park",
+    "trail"
+  ]
+}
+```
+
+### Create a synonym sets
+
+```python
+>>> client.create_synonym_set('us-national-parks', ["park", "trail"])
+{
+  "id": "syn-5b11ac72c9f9296b35220ac9",
+  "synonyms": [
+    "park",
+    "trail"
+  ]
+}
+```
+
+### Update a synonym sets
+
+```python
+>>> client.update_synonym_set('us-national-parks', 'syn-5b11ac72c9f9296b35220ac9', ["park", "trail", "ground"])
+{
+  "id": "syn-5b11ac72c9f9296b35220ac9",
+  "synonyms": [
+    "park",
+    "trail",
+    "ground"
+  ]
+}
+```
+
+### Delete a synonym sets
+
+```python
+>>> client.delete_synonym_set('us-national-parks', 'syn-5b11ac66c9f9292013220ad3')
+{
+  "deleted": true
+}
+```
+
 ### Searching
 
 ```python

--- a/swiftype_app_search/client.py
+++ b/swiftype_app_search/client.py
@@ -170,6 +170,61 @@ class Client:
         """
         return self.swiftype_session.request('delete', "engines/{}".format(engine_name))
 
+    def list_synonym_sets(self, engine_name, current=1, size=20):
+        """
+        Lists all synonym sets in engine.
+
+        :param engine_name: Name of the engine.
+        :param current: Page of synonym sets.
+        :param size: Number of synonym sets to return per page.
+        :return: List of synonym sets.
+        """
+        data = { 'page': { 'current': current, 'size': size } }
+        return self.swiftype_session.request('get', "engines/{}/synonyms".format(engine_name), json=data)
+
+    def get_synonym_set(self, engine_name, synonym_set_id):
+        """
+        Get a single synonym set.
+
+        :param engine_name: Name of the engine.
+        :param synonym_set_id: ID of the synonym set.
+        :return: A single synonym set.
+        """
+        return self.swiftype_session.request('get', "engines/{}/synonyms/{}".format(engine_name, synonym_set_id))
+
+    def create_synonym_set(self, engine_name, synonyms):
+        """
+        Create a synonym set.
+
+        :param engine_name: Name of the engine.
+        :param synonyms: List of synonyms.
+        :return: A list of synonyms that was created.
+        """
+        data = { 'synonyms': synonyms }
+        return self.swiftype_session.request('post', "engines/{}/synonyms".format(engine_name), json=data)
+
+    def update_synonym_set(self, engine_name, synonym_set_id, synonyms):
+        """
+        Update an existing synonym set.
+
+        :param engine_name: Name of the engine.
+        :param synonym_set_id: ID of the synonym set to update.
+        :param synonyms: The updated list of synonyms.
+        :return: The synonym set that was updated.
+        """
+        data = { 'synonyms': synonyms }
+        return self.swiftype_session.request('put', "engines/{}/synonyms/{}".format(engine_name, synonym_set_id), json=data)
+
+    def delete_synonym_set(self, engine_name, synonym_set_id):
+        """
+        Delete a synonym set.
+
+        :param engine_name: Name of the engine.
+        :param synonym_set_id: ID of the synonym set to be deleted.
+        :return: Delete status.
+        """
+        return self.swiftype_session.request('delete', "engines/{}/synonyms/{}".format(engine_name, synonym_set_id))
+
     def search(self, engine_name, query, options=None):
         """
         Search an engine. See https://swiftype.com/documentation/app-search/ for more details

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -238,6 +238,170 @@ class TestClient(TestCase):
             response = self.client.destroy_engine(engine_name)
             self.assertEqual(response, expected_return)
 
+    def test_list_synonym_sets(self):
+        expected_return = {
+            "meta": {
+                "page": {
+                    "current": 1,
+                    "total_pages": 1,
+                    "total_results": 3,
+                    "size": 20
+                }
+            },
+            "results": [
+                {
+                    "id": "syn-5b11ac66c9f9292013220ad3",
+                    "synonyms": [
+                        "park",
+                        "trail"
+                    ]
+                },
+                {
+                    "id": "syn-5b11ac72c9f9296b35220ac9",
+                    "synonyms": [
+                        "protected",
+                        "heritage"
+                    ]
+                },
+                {
+                    "id": "syn-5b11ac66c9f9292013220ad3",
+                    "synonyms": [
+                        "hectares",
+                        "acres"
+                    ]
+                }
+            ]
+        }
+
+        with requests_mock.Mocker() as m:
+            url = "{}/engines/{}/synonyms".format(
+                self.client.swiftype_session.base_url,
+                self.engine_name
+            )
+            m.register_uri(
+                'GET',
+                url,
+                additional_matcher=lambda x: x.text == '{"page": {"current": 1, "size": 20}}',
+                json=expected_return,
+                status_code=200
+            )
+
+            response = self.client.list_synonym_sets(self.engine_name)
+
+    def test_get_synonym_set(self):
+        synonym_id = 'syn-5b11ac66c9f9292013220ad3'
+        expected_return = {
+            "id": synonym_id,
+            "synonyms": [
+                "park",
+                "trail"
+            ]
+        }
+
+        with requests_mock.Mocker() as m:
+            url = "{}/engines/{}/synonyms/{}".format(
+                self.client.swiftype_session.base_url,
+                self.engine_name,
+                synonym_id
+            )
+            m.register_uri(
+                'GET',
+                url,
+                json=expected_return,
+                status_code=200
+            )
+
+            response = self.client.get_synonym_set(
+                self.engine_name,
+                synonym_id
+            )
+            self.assertEqual(response, expected_return)
+
+    def test_create_synonym_set(self):
+        synonym_set = ['park', 'trail']
+        expected_return = {
+            "id": "syn-5b11ac72c9f9296b35220ac9",
+            "synonyms": [
+                "park",
+                "trail"
+            ]
+        }
+
+        with requests_mock.Mocker() as m:
+            url = "{}/engines/{}/synonyms".format(
+                self.client.swiftype_session.base_url,
+                self.engine_name
+            )
+            m.register_uri(
+                'POST',
+                url,
+                json=expected_return,
+                status_code=200
+            )
+
+            response = self.client.create_synonym_set(
+                self.engine_name,
+                synonym_set
+            )
+            self.assertEqual(response, expected_return)
+
+    def test_update_synonym_set(self):
+        synonym_id = "syn-5b11ac72c9f9296b35220ac9"
+        synonym_set = ['park', 'trail', 'ground']
+        expected_return = {
+            "id": synonym_id,
+            "synonyms": [
+                "park",
+                "trail",
+                "ground"
+            ]
+        }
+
+        with requests_mock.Mocker() as m:
+            url = "{}/engines/{}/synonyms/{}".format(
+                self.client.swiftype_session.base_url,
+                self.engine_name,
+                synonym_id
+            )
+            m.register_uri(
+                'PUT',
+                url,
+                json=expected_return,
+                status_code=200
+            )
+
+            response = self.client.update_synonym_set(
+                self.engine_name,
+                synonym_id,
+                synonym_set
+            )
+            self.assertEqual(response, expected_return)
+
+    def test_delete_synonym_set(self):
+        synonym_id = 'syn-5b11ac66c9f9292013220ad3'
+        expected_return = {
+            "deleted": True
+        }
+
+        with requests_mock.Mocker() as m:
+            url = "{}/engines/{}/synonyms/{}".format(
+                self.client.swiftype_session.base_url,
+                self.engine_name,
+                synonym_id
+            )
+            m.register_uri(
+                'DELETE',
+                url,
+                json=expected_return,
+                status_code=200
+            )
+
+            response = self.client.delete_synonym_set(
+                self.engine_name,
+                synonym_id
+            )
+            self.assertEqual(response, expected_return)
+
     def test_search(self):
         query = 'query'
         expected_return = { 'meta': {}, 'results': []}


### PR DESCRIPTION
Add functionality to list, get, create, update and delete synonym sets via the client.

Closes #28 